### PR TITLE
Set starter metadata format files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+# top-most EditorConfig file
+root = true
+charset = utf-8
+trim_trailing_whitespace = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+
+[VERSION]
+insert_final_newline = false
+
+[Makefile]
+indent_style = tab
+
+[*.yml]
+indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Set default handling of line terminators:
+* text=auto
+
+# Handling of common file types in this repository:
+*.sh text
+*.ps1 text
+*.txt text
+*.yaml text
+*.yml text
+*.csv text

--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -1,0 +1,17 @@
+name: Linting of Dockerfile
+on:
+  push:
+    paths:
+      - Dockerfile
+      - .github/workflows/hadolint.yml
+
+jobs:
+  hadolint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Run hadolint on the primary Dockerfile
+        uses: burdzwastaken/hadolint-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HADOLINT_ACTION_DOCKERFILE_FOLDER: .

--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -10,8 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Run hadolint on the primary Dockerfile
-        uses: burdzwastaken/hadolint-action@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HADOLINT_ACTION_DOCKERFILE_FOLDER: .
+      - name: Hadolint
+        uses: docker://docker.io/cardboardci/hadolint:latest
+        with:
+          args: "hadolint Dockerfile"

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g netlify-cli
+RUN npm install -g netlify-cli@2.25.0
 
 USER cardboardci
 


### PR DESCRIPTION
Now that GitHub Actions, hadolint and other files are starting to get added to the repository, I have a concern with the formatting of the files. When switching between machines or projects, I might have different default settings for my formatting without realizing it. It makes sense for the repository to enforce a bit of a standard.

This PR adds in the starter for ensuring formatting consistency among all of the files in the project.